### PR TITLE
Fix async loops in chat thread deletion

### DIFF
--- a/src/features/chat-page/chat-services/chat-thread-service.ts
+++ b/src/features/chat-page/chat-services/chat-thread-service.ts
@@ -130,13 +130,13 @@ export const SoftDeleteChatThreadForCurrentUser = async (
       }
       const chats = chatResponse.response;
 
-      chats.forEach(async (chat) => {
+      for (const chat of chats) {
         const itemToUpdate = {
           ...chat,
         };
         itemToUpdate.isDeleted = true;
         await HistoryContainer().items.upsert(itemToUpdate);
-      });
+      }
 
       const chatDocumentsResponse = await FindAllChatDocuments(chatThreadID);
 
@@ -150,13 +150,13 @@ export const SoftDeleteChatThreadForCurrentUser = async (
         await DeleteDocuments(chatThreadID);
       }
 
-      chatDocuments.forEach(async (chatDocument: ChatDocumentModel) => {
+      for (const chatDocument of chatDocuments) {
         const itemToUpdate = {
           ...chatDocument,
         };
         itemToUpdate.isDeleted = true;
         await HistoryContainer().items.upsert(itemToUpdate);
-      });
+      }
 
       chatThreadResponse.response.isDeleted = true;
       await HistoryContainer().items.upsert(chatThreadResponse.response);


### PR DESCRIPTION
## Summary
- ensure chat thread deletion waits for database updates

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ef061700c8331b391ff36797c5cb2